### PR TITLE
chore(ci): upgrade actions/setup-python from v4 to v5 across all workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     
@@ -40,7 +40,7 @@ jobs:
         fetch-depth: 0
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     
@@ -69,7 +69,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Unit Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
-      matrix
+      matrix:
         python-version: ["3.11", "3.12"]
       fail-fast: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Unit Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
-      matrix:
+      matrix
         python-version: ["3.11", "3.12"]
       fail-fast: false
 
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
@@ -120,7 +120,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
## Description

Upgrades `actions/setup-python` from `@v4` to `@v5` in all three workflow files where it was outdated:
- `.github/workflows/test.yml` (3 jobs: unit-tests, integration-tests, build)
- - `.github/workflows/quality.yml` (3 jobs: lint, test-coverage, documentation)
- - `.github/workflows/security.yml` (1 job: security)
`ci.yml` was already on `@v5` — this PR brings the remaining files into consistency.

## Related Issue

Closes #75

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] - [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] - [ ] 📚 Documentation update
- [ ] - [x] 🔧 Configuration change
- [ ] - [ ] ✅ Test improvement
- [ ] - [ ] 🍊 Code style/refactoring (no functional changes)
- [ ] - [ ] ⚡ Performance improvement
## What changed

- `test.yml`: 3 occurrences of `setup-python@v4` → `@v5`
- - `quality.yml`: 3 occurrences of `setup-python@v4` → `@v5`
- - `security.yml`: 1 occurrence of `setup-python@v4` → `@v5`
`setup-python@v5` introduces support for Python 3.13, better caching behaviour, and several bug fixes over v4.