### PR TITLE
fix(ci): enable F821 ruff check and expand Python version matrix to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ ignore = [
     "F402",   # Import shadowed by loop var
     "F541",   # f-string without placeholders (cosmetic)
     "F811",   # Redefinition of unused name
-    "F821",   # Undefined name
     "F841",   # Local variable assigned but never used
     "W291",   # Trailing whitespace
     "W292",   # No newline at end of file


### PR DESCRIPTION
## Description

This PR fixes two CI configuration issues:

**1. Enable ruff F821 (undefined name) check — Closes #78**

Removes `"F821"` from the `[tool.ruff.lint].ignore` list in `pyproject.toml`. F821 detects references to names that are never defined, which can cause `NameError` at runtime. Suppressing it was silently allowing these bugs through CI.

**2. Add Python 3.13 to test matrix — Partially addresses #85**

Adds `"3.13"` to the `python-version` matrix in both `ci.yml` and `test.yml`. The project supports Python `>=3.10` but only tested against 3.11 and 3.12, leaving the latest stable release unchecked.

## Related Issues

Closes #78
Partially addresses #85

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] - [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] - [ ] 💥 Breaking change
- [ ] - [ ] 📚 Documentation update
- [ ] - [x] 🔧 Configuration change
- [ ] - [ ] ✅ Test improvement
- [ ] - [ ] 🍊 Code style/refactoring
- [ ] - [ ] ⚡ Performance improvement
## Files changed

- `pyproject.toml`: removed `"F821"` from `[tool.ruff.lint].ignore`
- - `.github/workflows/ci.yml`: added `"3.13"` to python-version matrix
- - `.github/workflows/test.yml`: added `"3.13"` to python-version matrix