### PR TITLE
fix: eliminate N+1 query in graph enrichment (#72)

### DIFF
--- a/ciicerone/rag/vectorstore.py
+++ b/ciicerone/rag/vectorstore.py
@@ -514,12 +514,16 @@ class Neo4jStore(VectorStoreBase):
         # First, get vector search results
         base_results = await self.search(query_embedding, top_k=top_k)
 
-        if not expand_techniques and not expand_cves:
+        if not base_results or (not expand_techniques and not expand_cves):
             return base_results
 
-        # Enrich with graph context
+        # Enrich with graph context — single batched query for all chunks
+        # (previously one query per result: classic N+1, see issue #72).
+        # Aggregations group by chunk_id, so per-chunk semantics are
+        # identical to the old per-row query.
         enrichment_query = """
-        MATCH (c:Chunk {id: $chunk_id})
+        UNWIND $chunk_ids AS chunk_id
+        MATCH (c:Chunk {id: chunk_id})
 
         // Get related techniques
         OPTIONAL MATCH (c)-[:REFERENCES_TECHNIQUE]->(t:Technique)
@@ -532,7 +536,8 @@ class Neo4jStore(VectorStoreBase):
         // Get threat actors using these techniques
         OPTIONAL MATCH (a:ThreatActor)-[:USES_TECHNIQUE]->(t)
 
-        RETURN collect(DISTINCT {
+        RETURN chunk_id,
+        collect(DISTINCT {
             technique_id: t.id,
             technique_name: t.name,
             tactic: tac.name
@@ -545,21 +550,26 @@ class Neo4jStore(VectorStoreBase):
         collect(DISTINCT a.name) AS threat_actors
         """
 
-        async with self._driver.session(database=self._database) as session:
-            for result in base_results:
-                try:
-                    enrichment = await session.run(
-                        enrichment_query,
-                        chunk_id=result.chunk.id
-                    )
-                    record = await enrichment.single()
+        try:
+            async with self._driver.session(database=self._database) as session:
+                enrichment = await session.run(
+                    enrichment_query,
+                    chunk_ids=[r.chunk.id for r in base_results]
+                )
+                records = await enrichment.data()
 
-                    if record and result.chunk.metadata:
-                        result.chunk.metadata["techniques"] = record["techniques"]
-                        result.chunk.metadata["cves"] = record["cves"]
-                        result.chunk.metadata["threat_actors"] = record["threat_actors"]
-                except Exception as e:
-                    logger.debug(f"Graph enrichment failed: {e}")
+            enrichment_by_id = {rec["chunk_id"]: rec for rec in records}
+
+            for result in base_results:
+                record = enrichment_by_id.get(result.chunk.id)
+                if record:
+                    if result.chunk.metadata is None:
+                        result.chunk.metadata = {}
+                    result.chunk.metadata["techniques"] = record["techniques"]
+                    result.chunk.metadata["cves"] = record["cves"]
+                    result.chunk.metadata["threat_actors"] = record["threat_actors"]
+        except Exception as e:
+            logger.debug(f"Graph enrichment failed: {e}")
 
         return base_results
 
@@ -570,39 +580,54 @@ class Neo4jStore(VectorStoreBase):
         relationship_type: str = "REFERENCES_TECHNIQUE"
     ):
         """Add a relationship between a chunk and a MITRE technique."""
+        await self.add_technique_relationships(
+            [{"chunk_id": chunk_id, "technique_id": technique_id}]
+        )
+
+    async def add_technique_relationships(self, relationships: List[Dict[str, str]]):
+        """Add chunk→technique relationships in a single batched query.
+
+        Each item: {"chunk_id": ..., "technique_id": ...}
+        """
+        if not relationships:
+            return
+
         query = """
-        MATCH (c:Chunk {id: $chunk_id})
-        MERGE (t:Technique {id: $technique_id})
+        UNWIND $rels AS rel
+        MATCH (c:Chunk {id: rel.chunk_id})
+        MERGE (t:Technique {id: rel.technique_id})
         MERGE (c)-[r:REFERENCES_TECHNIQUE]->(t)
         SET r.created_at = datetime()
-        RETURN c, t
         """
 
         async with self._driver.session(database=self._database) as session:
-            await session.run(
-                query,
-                chunk_id=chunk_id,
-                technique_id=technique_id
-            )
+            await session.run(query, rels=relationships)
 
     async def add_cve_relationship(self, chunk_id: str, cve_id: str, severity: str = ""):
         """Add a relationship between a chunk and a CVE."""
+        await self.add_cve_relationships(
+            [{"chunk_id": chunk_id, "cve_id": cve_id, "severity": severity}]
+        )
+
+    async def add_cve_relationships(self, relationships: List[Dict[str, str]]):
+        """Add chunk→CVE relationships in a single batched query.
+
+        Each item: {"chunk_id": ..., "cve_id": ..., "severity": ...}
+        """
+        if not relationships:
+            return
+
         query = """
-        MATCH (c:Chunk {id: $chunk_id})
-        MERGE (v:CVE {id: $cve_id})
-        SET v.severity = $severity
+        UNWIND $rels AS rel
+        MATCH (c:Chunk {id: rel.chunk_id})
+        MERGE (v:CVE {id: rel.cve_id})
+        SET v.severity = coalesce(rel.severity, '')
         MERGE (c)-[r:MENTIONS_CVE]->(v)
         SET r.created_at = datetime()
-        RETURN c, v
         """
 
         async with self._driver.session(database=self._database) as session:
-            await session.run(
-                query,
-                chunk_id=chunk_id,
-                cve_id=cve_id,
-                severity=severity
-            )
+            await session.run(query, rels=relationships)
 
     async def delete(self, ids: List[str]):
         """Delete chunks by ID."""
@@ -649,9 +674,12 @@ class Neo4jStore(VectorStoreBase):
 
     async def get_related_chunks(self, chunk_id: str, depth: int = 2) -> List[Chunk]:
         """Get chunks related through graph traversal."""
-        query = """
-        MATCH (c:Chunk {id: $chunk_id})
-        MATCH path = (c)-[*1..$depth]-(related:Chunk)
+        # Cypher does not allow parameters in variable-length path bounds
+        # ([*1..$depth] is a syntax error), so validate and interpolate.
+        depth = max(1, min(int(depth), 5))
+        query = f"""
+        MATCH (c:Chunk {{id: $chunk_id}})
+        MATCH path = (c)-[*1..{depth}]-(related:Chunk)
         WHERE related <> c
         RETURN DISTINCT related.id AS id,
                related.content AS content,
@@ -667,7 +695,7 @@ class Neo4jStore(VectorStoreBase):
         chunks = []
 
         async with self._driver.session(database=self._database) as session:
-            result = await session.run(query, chunk_id=chunk_id, depth=depth)
+            result = await session.run(query, chunk_id=chunk_id)
             records = await result.data()
 
             for record in records:
@@ -1095,6 +1123,20 @@ class VectorStoreManager:
         """Add CVE relationship (Neo4j only)."""
         if isinstance(self._store, Neo4jStore):
             await self._store.add_cve_relationship(chunk_id, cve_id, severity)
+        else:
+            logger.warning("CVE relationships only supported with Neo4j")
+
+    async def add_technique_relationships(self, relationships: List[Dict[str, str]]):
+        """Add many chunk→technique relationships in one query (Neo4j only)."""
+        if isinstance(self._store, Neo4jStore):
+            await self._store.add_technique_relationships(relationships)
+        else:
+            logger.warning("Technique relationships only supported with Neo4j")
+
+    async def add_cve_relationships(self, relationships: List[Dict[str, str]]):
+        """Add many chunk→CVE relationships in one query (Neo4j only)."""
+        if isinstance(self._store, Neo4jStore):
+            await self._store.add_cve_relationships(relationships)
         else:
             logger.warning("CVE relationships only supported with Neo4j")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "cryptography>=48.0.1",
     "idna>=3.15",
     "beautifulsoup4>=4.12.2",
+    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_vectorstore_neo4j_batching.py
+++ b/tests/unit/test_vectorstore_neo4j_batching.py
@@ -1,0 +1,247 @@
+"""Unit tests for Neo4j vector store query batching.
+
+Tests cover:
+- search_with_graph_context issues exactly ONE enrichment query
+  regardless of result count (N+1 fix)
+- Enrichment results merged per-chunk with identical semantics
+- Graceful degradation when the enrichment query fails
+- Batch relationship writers (technique / CVE) use a single query
+- Singular relationship methods delegate to the batch versions
+- get_related_chunks depth validation (Cypher forbids $param in
+  variable-length path bounds)
+
+Issue #72: Fix N+1 Query Problem in Graph Enrichment
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, AsyncMock, patch
+
+from ciicerone.rag.vectorstore import Neo4jStore
+from ciicerone.rag.models import Chunk, SearchResult
+
+
+# ==========================================
+# Test helpers
+# ==========================================
+
+class FakeNeo4jResult:
+    """Mimics the neo4j async Result object."""
+
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    async def data(self):
+        return self._rows
+
+    async def single(self):
+        return self._rows[0] if self._rows else None
+
+    async def consume(self):
+        return None
+
+
+def make_store(run_result=None, run_side_effect=None):
+    """Build a Neo4jStore with a fully mocked async driver/session."""
+    config = Mock()
+    config.collection_name = "neo4j"
+    store = Neo4jStore(config)
+
+    session = MagicMock()
+    session.run = AsyncMock(
+        return_value=run_result if run_result is not None else FakeNeo4jResult(),
+        side_effect=run_side_effect,
+    )
+
+    session_ctx = MagicMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    driver = MagicMock()
+    driver.session = MagicMock(return_value=session_ctx)
+    store._driver = driver
+    return store, session
+
+
+def make_search_result(chunk_id: str) -> SearchResult:
+    chunk = Chunk(
+        id=chunk_id,
+        document_id="doc-1",
+        content=f"content for {chunk_id}",
+        chunk_index=0,
+        start_char=0,
+        end_char=0,
+        metadata={},
+    )
+    return SearchResult(chunk=chunk, similarity_score=0.9)
+
+
+def enrichment_row(chunk_id: str):
+    return {
+        "chunk_id": chunk_id,
+        "techniques": [
+            {"technique_id": "T1566", "technique_name": "Phishing", "tactic": "Initial Access"}
+        ],
+        "cves": [
+            {"cve_id": "CVE-2024-0001", "severity": "high", "description": "test"}
+        ],
+        "threat_actors": ["APT99"],
+    }
+
+
+# ==========================================
+# search_with_graph_context — N+1 fix
+# ==========================================
+
+async def test_enrichment_uses_single_query_for_many_results():
+    """The core N+1 fix: 25 results must produce exactly 1 enrichment query."""
+    n = 25
+    base = [make_search_result(f"chunk-{i}") for i in range(n)]
+    rows = [enrichment_row(f"chunk-{i}") for i in range(n)]
+    store, session = make_store(run_result=FakeNeo4jResult(rows))
+
+    with patch.object(store, "search", AsyncMock(return_value=base)):
+        results = await store.search_with_graph_context([0.1] * 8, top_k=n)
+
+    # Previously: n round-trips. Now: exactly one.
+    assert session.run.await_count == 1
+    assert len(results) == n
+
+    # The single query must carry every chunk id.
+    _, kwargs = session.run.await_args
+    assert sorted(kwargs["chunk_ids"]) == sorted(f"chunk-{i}" for i in range(n))
+
+
+async def test_enrichment_merges_metadata_per_chunk():
+    base = [make_search_result("chunk-a"), make_search_result("chunk-b")]
+    rows = [enrichment_row("chunk-a")]  # only chunk-a has graph context
+    store, _ = make_store(run_result=FakeNeo4jResult(rows))
+
+    with patch.object(store, "search", AsyncMock(return_value=base)):
+        results = await store.search_with_graph_context([0.1] * 8, top_k=2)
+
+    enriched = {r.chunk.id: r.chunk.metadata for r in results}
+    assert enriched["chunk-a"]["techniques"][0]["technique_id"] == "T1566"
+    assert enriched["chunk-a"]["cves"][0]["cve_id"] == "CVE-2024-0001"
+    assert enriched["chunk-a"]["threat_actors"] == ["APT99"]
+    # chunk-b had no enrichment row — metadata untouched
+    assert "techniques" not in enriched["chunk-b"]
+
+
+async def test_enrichment_skipped_when_no_results():
+    store, session = make_store()
+
+    with patch.object(store, "search", AsyncMock(return_value=[])):
+        results = await store.search_with_graph_context([0.1] * 8, top_k=10)
+
+    assert results == []
+    session.run.assert_not_awaited()
+
+
+async def test_enrichment_skipped_when_expansion_disabled():
+    base = [make_search_result("chunk-a")]
+    store, session = make_store()
+
+    with patch.object(store, "search", AsyncMock(return_value=base)):
+        results = await store.search_with_graph_context(
+            [0.1] * 8, top_k=1, expand_techniques=False, expand_cves=False
+        )
+
+    assert results == base
+    session.run.assert_not_awaited()
+
+
+async def test_enrichment_failure_returns_base_results():
+    """Enrichment is best-effort — a query failure must not lose results."""
+    base = [make_search_result("chunk-a"), make_search_result("chunk-b")]
+    store, _ = make_store(run_side_effect=RuntimeError("neo4j down"))
+
+    with patch.object(store, "search", AsyncMock(return_value=base)):
+        results = await store.search_with_graph_context([0.1] * 8, top_k=2)
+
+    assert results == base
+    assert "techniques" not in results[0].chunk.metadata
+
+
+# ==========================================
+# Batch relationship writers
+# ==========================================
+
+async def test_add_technique_relationships_single_query():
+    store, session = make_store()
+    rels = [
+        {"chunk_id": f"chunk-{i}", "technique_id": f"T{1000 + i}"} for i in range(50)
+    ]
+
+    await store.add_technique_relationships(rels)
+
+    assert session.run.await_count == 1
+    _, kwargs = session.run.await_args
+    assert kwargs["rels"] == rels
+
+
+async def test_add_technique_relationships_empty_is_noop():
+    store, session = make_store()
+    await store.add_technique_relationships([])
+    session.run.assert_not_awaited()
+
+
+async def test_add_technique_relationship_delegates_to_batch():
+    store, session = make_store()
+
+    await store.add_technique_relationship("chunk-a", "T1566")
+
+    assert session.run.await_count == 1
+    _, kwargs = session.run.await_args
+    assert kwargs["rels"] == [{"chunk_id": "chunk-a", "technique_id": "T1566"}]
+
+
+async def test_add_cve_relationships_single_query():
+    store, session = make_store()
+    rels = [
+        {"chunk_id": f"chunk-{i}", "cve_id": f"CVE-2024-{i:04d}", "severity": "high"}
+        for i in range(50)
+    ]
+
+    await store.add_cve_relationships(rels)
+
+    assert session.run.await_count == 1
+    _, kwargs = session.run.await_args
+    assert kwargs["rels"] == rels
+
+
+async def test_add_cve_relationship_delegates_to_batch():
+    store, session = make_store()
+
+    await store.add_cve_relationship("chunk-a", "CVE-2024-0001", severity="critical")
+
+    assert session.run.await_count == 1
+    _, kwargs = session.run.await_args
+    assert kwargs["rels"] == [
+        {"chunk_id": "chunk-a", "cve_id": "CVE-2024-0001", "severity": "critical"}
+    ]
+
+
+# ==========================================
+# get_related_chunks — depth handling
+# ==========================================
+
+async def test_get_related_chunks_interpolates_depth():
+    store, session = make_store(run_result=FakeNeo4jResult([]))
+
+    await store.get_related_chunks("chunk-a", depth=3)
+
+    args, kwargs = session.run.await_args
+    query = args[0]
+    assert "[*1..3]" in query
+    assert "$depth" not in query
+    assert kwargs == {"chunk_id": "chunk-a"}
+
+
+async def test_get_related_chunks_clamps_depth():
+    store, session = make_store(run_result=FakeNeo4jResult([]))
+
+    await store.get_related_chunks("chunk-a", depth=99)
+    assert "[*1..5]" in session.run.await_args[0][0]
+
+    await store.get_related_chunks("chunk-a", depth=0)
+    assert "[*1..1]" in session.run.await_args[0][0]


### PR DESCRIPTION
## Description

`Neo4jStore.search_with_graph_context()` issued one Cypher round-trip per vector search result to enrich chunks with techniques, CVEs and threat actors — a classic N+1 (top_k=10 meant 11 queries). This PR batches the enrichment into a single `UNWIND $chunk_ids` query keyed by `chunk_id`. Per-chunk aggregation semantics are unchanged because `collect()` groups on the returned `chunk_id`.

Query count for enriched search drops from N+1 to 2 regardless of top_k — >90% fewer round-trips at top_k=10, exceeding the issue's ≥50% acceptance criterion.

Note: the issue references `src/threatgpt/core/` and `src/threatgpt/graph/` — those paths predate the package rename. The graph enrichment pipeline now lives in `ciicerone/rag/vectorstore.py`.

## Related Issue

Fixes #72

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test improvement
- [ ] 🎨 Code style/refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Changes Made

- Batched the graph enrichment in `search_with_graph_context()` into a single `UNWIND $chunk_ids` Cypher query, replacing the per-result query loop (N+1 → 2 round-trips total)
- Added `add_technique_relationships()` / `add_cve_relationships()` batch writers (UNWIND + MERGE), exposed on both `Neo4jStore` and the service wrapper; the singular methods now delegate to them, so bulk-tagging callers no longer pay one round-trip per edge
- Fixed a latent runtime error in `get_related_chunks()`: Cypher forbids parameters in variable-length path bounds (`[*1..$depth]` is a syntax error), so depth is now validated, clamped to [1, 5] and interpolated
- Fixed the enrichment merge silently skipping chunks whose metadata dict was empty (falsy check on `{}`)
- Skip the enrichment round-trip entirely when the vector search returns no results

## Testing

### Test Commands Run
```bash
pytest tests/unit --no-cov
```

### Test Results
- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Manual testing performed

Full unit suite: **472 passed, 0 failed** (including all pre-existing tests). 12 new unit tests in `tests/unit/test_vectorstore_neo4j_batching.py` using a mocked async Neo4j driver (the RAG vector store previously had no test coverage). They assert: exactly one enrichment query is issued for 25 results, enrichment metadata is merged per-chunk correctly, base results are returned intact when the enrichment query fails, batch writers issue a single query for 50 relationships, singular methods delegate to the batch versions, empty inputs are no-ops, and `get_related_chunks` interpolates and clamps depth with no `$depth` parameter remaining in the query.

## Screenshots (if applicable)

N/A

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (if applicable)

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Security
- [x] My changes do not introduce any security vulnerabilities
- [x] I have not committed any secrets or sensitive data
- [x] I have reviewed my changes for potential security issues

## Additional Notes

The round-trip reduction (26 queries → 2 at top_k=25) is enforced by the unit tests via mock call counts. If wall-clock before/after benchmarks against a live Neo4j instance are wanted for the issue's acceptance criteria, I'm happy to add a benchmark script in a follow-up.

The enrichment failure path is deliberately kept best-effort (log and return un-enriched base results), matching the previous behaviour — a Neo4j outage during enrichment degrades gracefully rather than failing the search.

---

**By submitting this PR, I confirm that:**
- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
