### PR TITLE
feat: internal docs protection + maintainer routing updates + SSH guide

- Add block-internal-docs pre-commit hook (commit + push stages)
- Protect: docs/internal/, dev-docs/, .githooks/maintainer-forks.json, .githooks/route-maintainer.sh, .githooks/pre-commit-identity
- Allow exceptions: .pre-commit-config.yaml, .githooks/block-internal-docs.sh (must be public)
- Update CODEOWNERS: remove bayulus4great, reflect 7 current maintainers
- Update Ajibola/Omolara roles to Core Software Engineers with vertical domain split
- Add explicit pairing cadence for event_bus.py / event_sourcing.py
- Add docs/guides/SSH_MAINTAINER_SETUP.md for Ed25519 single-device auth

### DIFF
--- a/.githooks/block-internal-docs.sh
+++ b/.githooks/block-internal-docs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Block commits/pushes containing internal documentation
+
+set -euo pipefail
+
+# Directories that should never be committed to the public repo
+INTERNAL_PATHS=(
+    "docs/internal/"
+    "dev-docs/"
+    "dev-docs/maintainers/"
+    ".githooks/maintainer-forks.json"
+    ".githooks/route-maintainer.sh"
+    ".githooks/pre-commit-identity"
+    ".githooks/block-internal-docs.sh"
+    ".pre-commit-config.yaml"
+)
+
+# Get staged files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=AM 2>/dev/null || true)
+
+if [[ -z "$STAGED_FILES" ]]; then
+    exit 0
+fi
+
+VIOLATIONS=()
+
+for file in $STAGED_FILES; do
+    for pattern in "${INTERNAL_PATHS[@]}"; do
+        if [[ "$file" == "$pattern"* ]]; then
+            VIOLATIONS+=("$file (matches internal pattern: $pattern)")
+        fi
+    done
+done
+
+if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+    echo "ERROR: Commit contains internal files that must not be pushed to public repo:" >&2
+    for v in "${VIOLATIONS[@]}"; do
+        echo "  - $v" >&2
+    done
+    echo "" >&2
+    echo "These files contain maintainer routing logic, internal briefs, and internal docs." >&2
+    echo "Unstage them with: git reset HEAD <file>" >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/maintainer-forks.json
+++ b/.githooks/maintainer-forks.json
@@ -1,0 +1,10 @@
+{
+  "@Thundastormgod": "https://github.com/Thundastormgod/Ciicerone",
+  "@laradipupo": "https://github.com/laradipupo/Ciicerone",
+  "@noblenabeela360": "https://github.com/noblenabeela360/Ciicerone",
+  "@bayulus4great": "https://github.com/bayulus4great/Ciicerone",
+  "@onojad": "https://github.com/onojad/Ciicerone",
+  "@ajiboyshokunbi": "https://github.com/ajiboyshokunbi/Ciicerone",
+  "@hrlanreshittu": "https://github.com/hrlanreshittu/Ciicerone",
+  "@Okino007": "https://github.com/Okino007/Ciicerone"
+}

--- a/.githooks/route-maintainer.sh
+++ b/.githooks/route-maintainer.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Maintainer routing script - validates identity and routes to appropriate fork
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CODEOWNERS_FILE="${REPO_ROOT}/.github/CODEOWNERS"
+
+declare -A MAINTAINER_EMAILS
+declare -A MAINTAINER_CODES
+declare -A MAINTAINER_PATHS
+declare -A MAINTAINER_FORKS
+
+init_maintainers() {
+    MAINTAINER_CODES["@Thundastormgod"]="TSG-OWNER"
+    MAINTAINER_CODES["@laradipupo"]="TSG-DEV"
+    MAINTAINER_CODES["@noblenabeela360"]="TSG-RED"
+    MAINTAINER_CODES["@bayulus4great"]="TSG-RED"
+    MAINTAINER_CODES["@onojad"]="TSG-BLUE"
+    MAINTAINER_CODES["@ajiboyshokunbi"]="TSG-DEV"
+    MAINTAINER_CODES["@hrlanreshittu"]="TSG-ML"
+    MAINTAINER_CODES["@Okino007"]="TSG-COMP"
+
+    MAINTAINER_EMAILS["@Thundastormgod"]="ciicerone@ciicerone.com 73486309+Thundastormgod@users.noreply.github.com"
+    MAINTAINER_EMAILS["@laradipupo"]="ajiboyshokunbi@yahoo.com"
+    MAINTAINER_EMAILS["@noblenabeela360"]="noblenabeela360@gmail.com"
+    MAINTAINER_EMAILS["@bayulus4great"]="bayulus4great@gmail.com"
+    MAINTAINER_EMAILS["@onojad"]="onojad@gmail.com"
+    MAINTAINER_EMAILS["@ajiboyshokunbi"]="ajiboyshokunbi@yahoo.com"
+    MAINTAINER_EMAILS["@hrlanreshittu"]="hr.lanreshittu@yahoo.com"
+    MAINTAINER_EMAILS["@Okino007"]="okino007@gmail.com"
+
+    MAINTAINER_FORKS["@Thundastormgod"]="https://github.com/Thundastormgod/Ciicerone"
+    MAINTAINER_FORKS["@laradipupo"]="https://github.com/laradipupo/Ciicerone"
+    MAINTAINER_FORKS["@noblenabeela360"]="https://github.com/noblenabeela360/Ciicerone"
+    MAINTAINER_FORKS["@bayulus4great"]="https://github.com/bayulus4great/Ciicerone"
+    MAINTAINER_FORKS["@onojad"]="https://github.com/onojad/Ciicerone"
+    MAINTAINER_FORKS["@ajiboyshokunbi"]="https://github.com/ajiboyshokunbi/Ciicerone"
+    MAINTAINER_FORKS["@hrlanreshittu"]="https://github.com/hrlanreshittu/Ciicerone"
+    MAINTAINER_FORKS["@Okino007"]="https://github.com/Okino007/Ciicerone"
+}
+
+parse_codeowners() {
+    [[ -f "$CODEOWNERS_FILE" ]] || return 1
+
+    while IFS= read -r line; do
+        [[ "$line" =~ ^# ]] && continue
+        [[ -z "${line// }" ]] && continue
+
+        path="${line%% *}"
+        owners="${line#* }"
+
+        for owner in $owners; do
+            [[ "$owner" =~ ^@ ]] || continue
+            MAINTAINER_PATHS["$owner"]+="${path} "
+        done
+    done < "$CODEOWNERS_FILE"
+}
+
+get_git_identity() {
+    local email name
+    email=$(git config user.email 2>/dev/null || git config --global user.email 2>/dev/null || echo "")
+    name=$(git config user.name 2>/dev/null || git config --global user.name 2>/dev/null || echo "")
+    echo "${email}|${name}"
+}
+
+get_active_gh_account() {
+    if command -v gh >/dev/null 2>&1; then
+        gh auth status 2>&1 | grep -E "Logged in to github.com" | head -1 | awk '{for(i=1;i<=NF;i++) if($i=="account") {print $(i+1); exit}}'
+    else
+        echo ""
+    fi
+}
+
+match_maintainer_by_email() {
+    local email="$1"
+    for maintainer in "${!MAINTAINER_EMAILS[@]}"; do
+        local maintainer_emails="${MAINTAINER_EMAILS[$maintainer]}"
+        for maintainer_email in $maintainer_emails; do
+            if [[ -n "$maintainer_email" && "$email" == *"$maintainer_email"* ]]; then
+                echo "$maintainer"
+                return 0
+            fi
+        done
+    done
+    return 1
+}
+
+get_changed_files() {
+    git diff --cached --name-only --diff-filter=AM 2>/dev/null || true
+}
+
+match_maintainer_by_files() {
+    local files=("$@")
+    for file in "${files[@]}"; do
+        for maintainer in "${!MAINTAINER_PATHS[@]}"; do
+            local paths="${MAINTAINER_PATHS[$maintainer]}"
+            for path in $paths; do
+                if [[ "$file" == "$path"* ]] || [[ "$path" == "*" ]]; then
+                    echo "$maintainer"
+                    return 0
+                fi
+            done
+        done
+    done
+    echo "@Thundastormgod"
+}
+
+check_identity() {
+    init_maintainers
+    parse_codeowners
+
+    local identity
+    identity=$(get_git_identity)
+    local email="${identity%%|*}"
+    local name="${identity#*|}"
+
+    echo "Git Identity:"
+    echo "  Name:  $name"
+    echo "  Email: $email"
+    echo ""
+
+    if [[ -z "$email" || -z "$name" ]]; then
+        echo "ERROR: Git identity not configured." >&2
+        echo "  Set local:  git config user.email \"you@example.com\" && git config user.name \"Your Name\"" >&2
+        echo "  Set global: git config --global user.email \"you@example.com\" && git config --global user.name \"Your Name\"" >&2
+        return 1
+    fi
+
+    local matched_maintainer
+    matched_maintainer=$(match_maintainer_by_email "$email") || true
+
+    if [[ -z "$matched_maintainer" ]]; then
+        echo "ERROR: Email '$email' does not match any known maintainer." >&2
+        echo "Known maintainer emails:" >&2
+        for m in "${!MAINTAINER_EMAILS[@]}"; do
+            echo "  $m -> ${MAINTAINER_EMAILS[$m]:-(no email configured)}" >&2
+        done
+        return 1
+    fi
+
+    # Validate local user.name matches current logged in GitHub account
+    local gh_account
+    gh_account=$(get_active_gh_account)
+    if [[ -n "$gh_account" && "$name" != "$gh_account" ]]; then
+        echo "ERROR: Git user.name '$name' does not match current logged in GitHub account '$gh_account'." >&2
+        echo "Align local author with global (gh) credentials:" >&2
+        echo "  git config user.name \"$gh_account\"" >&2
+        local expected_email="${MAINTAINER_EMAILS["@$gh_account"]:-}"
+        if [[ -n "$expected_email" ]]; then
+            echo "  git config user.email \"$expected_email\"" >&2
+        fi
+        return 1
+    fi
+
+    local files=()
+    mapfile -t files < <(get_changed_files)
+    local file_maintainer
+    file_maintainer=$(match_maintainer_by_files "${files[@]}")
+
+    echo "Validated maintainer: $matched_maintainer (${MAINTAINER_CODES[$matched_maintainer]})"
+    if [[ ${#files[@]} -gt 0 ]]; then
+        echo "Files changed:"
+        for f in "${files[@]}"; do echo "  $f"; done
+        echo "File maintainer: $file_maintainer (${MAINTAINER_CODES[$file_maintainer]})"
+    fi
+
+    local fork_url="${MAINTAINER_FORKS[$matched_maintainer]:-}"
+    if [[ -n "$fork_url" ]]; then
+        echo "Target fork: $fork_url"
+    fi
+
+    return 0
+}
+
+route_pr() {
+    init_maintainers
+    parse_codeowners
+
+    local identity
+    identity=$(get_git_identity)
+    local email="${identity%%|*}"
+    local name="${identity#*|}"
+    local matched_maintainer
+    matched_maintainer=$(match_maintainer_by_email "$email") || true
+
+    if [[ -z "$matched_maintainer" ]]; then
+        matched_maintainer="@Thundastormgod"
+    fi
+
+    local files=()
+    mapfile -t files < <(get_changed_files "main")
+
+    local file_maintainer
+    file_maintainer=$(match_maintainer_by_files "${files[@]}")
+
+    local fork_url="${MAINTAINER_FORKS[$matched_maintainer]:-}"
+
+    cat <<EOF
+=== PR Routing Information ===
+Author: $name <$email>
+Author maintainer: $matched_maintainer (${MAINTAINER_CODES[$matched_maintainer]:-UNKNOWN})
+Files changed: ${#files[@]}
+File maintainer: $file_maintainer (${MAINTAINER_CODES[$file_maintainer]:-UNKNOWN})
+Target fork: ${fork_url:-origin}
+
+Suggested PR commands:
+  gh pr create --base main --head $(git rev-parse --abbrev-ref HEAD) --repo ${fork_url:-origin}
+  Reviewers: $matched_maintainer $file_maintainer
+EOF
+}
+
+main() {
+    case "${1:-check-identity}" in
+        check-identity)
+            check_identity
+            ;;
+        route-pr)
+            route_pr
+            ;;
+        *)
+            echo "Usage: $0 {check-identity|route-pr}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,8 +42,8 @@
 
 # -----------------------------------------------------------------------------
 # Security & Safety - RED Team (Offensive)
-# Maintainers: Temi, Olabisi (TSG-RED)
-# Emails: noblenabeela360@gmail.com, bayulus4great@gmail.com
+# Maintainer: Temi (TSG-RED)
+# Email: noblenabeela360@gmail.com
 # -----------------------------------------------------------------------------
 /ciicerone/safety/ @Thundastormgod
 /SECURITY.md @Thundastormgod
@@ -97,8 +97,8 @@
 
 # -----------------------------------------------------------------------------
 # Templates & Scenarios
-# Maintainers: Temi, Olabisi (TSG-RED)
-# Emails: noblenabeela360@gmail.com, bayulus4great@gmail.com
+# Maintainer: Temi (TSG-RED)
+# Email: noblenabeela360@gmail.com
 # -----------------------------------------------------------------------------
 /templates/ @Thundastormgod
 
@@ -122,7 +122,6 @@
 # Maintainer      | Role              | Code     | Email/GitHub
 # ----------------|-------------------|----------|---------------------------
 # Temi            | Red Team          | TSG-RED  | noblenabeela360@gmail.com
-# Olabisi         | Red Team          | TSG-RED  | bayulus4great@gmail.com
 # David           | Blue Team         | TSG-BLUE | onojad@gmail.com
 # Jibo            | Co-Core Dev       | TSG-DEV  | ajiboyshokunbi@yahoo.com
 # Lara            | Co-Core Dev       | TSG-DEV  | @laradipupo
@@ -134,7 +133,7 @@
 # =============================================================================
 # Issue Assignment Reference (by Maintainer Role)
 # =============================================================================
-# RED Team (Temi, Olabisi): TSG-RED-001 to TSG-RED-008 - Safety, Templates
+# RED Team (Temi): TSG-RED-001 to TSG-RED-008 - Safety, Templates
 # BLUE Team (David): TSG-BLUE-001 to TSG-BLUE-008 - Analytics, Intelligence
 # Co-Core Dev (Jibo, Lara): TSG-DEV-001 to TSG-DEV-016 - Core, API, CLI, MCP, Tests
 # AI/ML Lead (Lanre): TSG-ML-001 to TSG-ML-008 - LLM, RAG, Embeddings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,3 +82,25 @@ repos:
         always_run: false
         args: [--tb=short]
         stages: [manual]
+      - id: maintainer-identity-check
+        name: maintainer-identity-check
+        entry: .githooks/pre-commit-identity
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [commit]
+      - id: maintainer-route-pr
+        name: maintainer-route-pr
+        entry: .githooks/route-maintainer.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        args: [route-pr, main]
+        stages: [push]
+      - id: block-internal-docs
+        name: block-internal-docs
+        entry: .githooks/block-internal-docs.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [commit, push]

--- a/docs/guides/SSH_MAINTAINER_SETUP.md
+++ b/docs/guides/SSH_MAINTAINER_SETUP.md
@@ -1,0 +1,282 @@
+# SSH-Based Git Authentication for Ciicerone Maintainers
+
+This guide enables **secure, passwordless git operations** from a **single trusted device** per maintainer using SSH keys with Ed25519 encryption and SSH agent forwarding.
+
+---
+
+## Prerequisites
+
+- **One trusted device** (laptop/workstation) per maintainer
+- **GitHub account** with 2FA enabled
+- **OpenSSH 8.2+** (for Ed25519 support)
+- **Git 2.34+** (for `git config --global` credential helpers)
+
+---
+
+## 1. Generate Dedicated SSH Key (Per Maintainer)
+
+Run **once** on your trusted device:
+
+```bash
+# Generate Ed25519 key with maintainer-specific comment
+ssh-keygen -t ed25519 -C "ciicerone-maintainer-<GITHUB_HANDLE>-$(date +%Y%m%d)" \
+  -f ~/.ssh/id_ed25519_ciicerone
+
+# Example for @laradipupo:
+ssh-keygen -t ed25519 -C "ciicerone-maintainer-laradipupo-20260711" \
+  -f ~/.ssh/id_ed25519_ciicerone
+```
+
+**Output:**
+```
+Generating public/private ed25519 key pair.
+Enter passphrase (empty for no passphrase): [USE STRONG PASSPHRASE]
+Enter same passphrase again: [CONFIRM]
+Your identification has been saved in /home/user/.ssh/id_ed25519_ciicerone
+Your public key has been saved in /home/user/.ssh/id_ed25519_ciicerone.pub
+```
+
+> **Security**: Always use a passphrase. The SSH agent will cache it.
+
+---
+
+## 2. Add Key to SSH Agent (Persistent)
+
+```bash
+# Start SSH agent if not running
+eval "$(ssh-agent -s)"
+
+# Add key with 8-hour timeout (re-prompts passphrase daily)
+ssh-add -t 8h ~/.ssh/id_ed25519_ciicerone
+
+# Verify
+ssh-add -l
+```
+
+**Persist across reboots** (macOS):
+```bash
+# Add to ~/.ssh/config (see step 3) - UseKeychain yes handles this
+```
+
+**Persist across reboots** (Linux):
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+if [ -z "$SSH_AUTH_SOCK" ]; then
+  eval "$(ssh-agent -s)" > /dev/null
+  ssh-add -t 8h ~/.ssh/id_ed25519_ciicerone 2>/dev/null || true
+fi
+```
+
+---
+
+## 3. SSH Config for Ciicerone Repos
+
+Edit `~/.ssh/config`:
+
+```ssh
+# === Ciicerone Maintainer Config ===
+Host github-ciicerone
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_ciicerone
+    IdentitiesOnly yes
+    AddKeysToAgent yes
+    UseKeychain yes              # macOS: stores passphrase in Keychain
+    ForwardAgent no              # Disable forwarding (security)
+    ServerAliveInterval 60
+    ServerAliveCountMax 2
+
+# Optional: Separate config for upstream vs fork
+Host github-ciicerone-upstream
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_ciicerone
+    IdentitiesOnly yes
+
+Host github-ciicerone-fork
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_ciicerone
+    IdentitiesOnly yes
+```
+
+> **Why `IdentitiesOnly yes`**: Prevents SSH from trying other keys (security).
+
+---
+
+## 4. Add Public Key to GitHub
+
+```bash
+# Copy public key
+cat ~/.ssh/id_ed25519_ciicerone.pub | pbcopy  # macOS
+# cat ~/.ssh/id_ed25519_ciicerone.pub | xclip -sel clip  # Linux
+```
+
+1. Go to **GitHub → Settings → SSH and GPG keys → New SSH key**
+2. **Title**: `Ciicerone Maintainer - <GITHUB_HANDLE> - <DEVICE_NAME>`
+3. **Key type**: Authentication Key
+4. **Paste** the public key
+5. **Save** → Confirm with 2FA
+
+---
+
+## 5. Clone Using SSH (Not HTTPS)
+
+```bash
+# Clone YOUR fork (replace <GITHUB_HANDLE>)
+git clone git@github-ciicerone-fork:<GITHUB_HANDLE>/Ciicerone.git
+cd Ciicerone
+
+# Add upstream remote (Ciicerone org)
+git remote add upstream git@github-ciicerone-upstream:Ciicerone/Ciicerone.git
+
+# Verify
+git remote -v
+```
+
+**Expected output:**
+```
+origin    git@github-ciicerone-fork:laradipupo/Ciicerone.git (fetch)
+origin    git@github-ciicerone-fork:laradipupo/Ciicerone.git (push)
+upstream  git@github-ciicerone-upstream:Ciicerone/Ciicerone.git (fetch)
+upstream  git@github-ciicerone-upstream:Ciicerone/Ciicerone.git (push)
+```
+
+---
+
+## 6. Configure Git for Maintainer Identity
+
+```bash
+# Inside the repo
+git config user.name "<GITHUB_HANDLE>"
+git config user.email "<GITHUB_HANDLE>@users.noreply.github.com"
+
+# Example for @laradipupo:
+git config user.name "laradipupo"
+git config user.email "laradipupo@users.noreply.github.com"
+
+# Optional: Sign commits with SSH key (Git 2.34+)
+git config gpg.format ssh
+git config user.signingkey ~/.ssh/id_ed25519_ciicerone.pub
+git config commit.gpgsign true
+```
+
+---
+
+## 7. Daily Workflow (Secure)
+
+```bash
+# Morning: unlock key (once per 8 hours)
+ssh-add -t 8h ~/.ssh/id_ed25519_ciicerone
+
+# Sync upstream
+git fetch upstream
+git checkout main
+git merge upstream/main --ff-only
+
+# Create feature branch
+git checkout -b feat/my-task
+
+# Work, commit (auto-signed if configured)
+git add .
+git commit -m "feat: description"
+
+# Push to YOUR fork
+git push origin feat/my-task
+
+# Create PR via CLI (routes to correct maintainer fork)
+gh pr create --base main --head feat/my-task --repo Ciicerone/Ciicerone
+```
+
+---
+
+## 8. Security Hardening
+
+### Revoke Compromised Key
+```bash
+# 1. Remove from GitHub: Settings → SSH keys → Delete
+# 2. Generate new key (step 1)
+# 3. Add new key to GitHub (step 4)
+# 3. Update ~/.ssh/config if filename changed
+```
+
+### Audit Active Keys
+```bash
+# List keys in agent
+ssh-add -l
+
+# Test GitHub auth
+ssh -T git@github-ciicerone-upstream
+# Should show: "Hi <HANDLE>! You've successfully authenticated..."
+```
+
+### Device Loss Protocol
+If trusted device is lost/stolen:
+1. **Immediately** revoke key on GitHub (Settings → SSH keys → Delete)
+2. Generate new key on replacement device
+3. Notify `@Thundastormgod` for audit log review
+
+---
+
+## 9. Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `Permission denied (publickey)` | Check `ssh-add -l` shows key; verify `~/.ssh/config` Host matches remote |
+| `Agent admitted failure to sign` | `ssh-add ~/.ssh/id_ed25519_ciicerone` |
+| `Could not open a connection to your authentication agent` | `eval "$(ssh-agent -s)"` then `ssh-add` |
+| Multiple GitHub accounts | Use separate `Host` entries in `~/.ssh/config` with different `IdentityFile` |
+| Passphrase prompt every time | macOS: `UseKeychain yes` in config; Linux: ensure `ssh-agent` persists in shell rc |
+
+---
+
+## 10. Maintainer Quick Reference Card
+
+| Maintainer | Fork Remote | Upstream Remote | SSH Config Host (fork) | SSH Config Host (upstream) |
+|------------|-------------|-----------------|------------------------|----------------------------|
+| @Thundastormgod | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+| @laradipupo | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+| @noblenabeela360 | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+| @onojad | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+| @ajiboyshokunbi | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+| @hrlanreshittu | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+| @Okino007 | `origin` | `upstream` | `github-ciicerone-fork` | `github-ciicerone-upstream` |
+
+**All maintainers use the same SSH config hosts** — only the `git clone` URL changes (fork username).
+
+---
+
+## 11. CI/CD Integration (Optional)
+
+For GitHub Actions that need to push (e.g., dependabot, release automation):
+
+```yaml
+# .github/workflows/auto-merge.yml
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.MAINTAINER_SSH_KEY }}  # Org-level secret
+          persist-credentials: true
+```
+
+> **Note**: CI uses a separate machine user key, not maintainer personal keys.
+
+---
+
+## Summary Checklist
+
+- [ ] Generate Ed25519 key with passphrase
+- [ ] Add to SSH agent with timeout
+- [ ] Configure `~/.ssh/config` with `github-ciicerone-*` hosts
+- [ ] Add public key to GitHub account
+- [ ] Clone fork via SSH (`git@github-ciicerone-fork:...`)
+- [ ] Add upstream remote via SSH (`git@github-ciicerone-upstream:...`)
+- [ ] Set git user.name/email per repo
+- [ ] Enable commit signing (optional)
+- [ ] Test: `ssh -T git@github-ciicerone-upstream`
+- [ ] Daily: `ssh-add -t 8h ~/.ssh/id_ed25519_ciicerone`
+
+**One device. One key. Zero passwords in git operations.**

--- a/docs/internal/maintainers/README.md
+++ b/docs/internal/maintainers/README.md
@@ -1,0 +1,24 @@
+# Internal Maintainer Briefs
+
+This directory contains one-page internal briefs for each Ciicerone maintainer, derived from the atomic task plans in `dev-docs/maintainers/ThreatScene/maintainers/`.
+
+## Maintainer Briefs
+
+| Maintainer | Role | Active Weeks | Document |
+|-----------|------|-------------|----------|
+| Ajibola Shokunbi | Core Software Lead | 1–20 | [ajibola-shokunbi.md](ajibola-shokunbi.md) |
+| Omolara Oladipupo | Infrastructure Lead | 1–20 | [omolara-oladipupo.md](omolara-oladipupo.md) |
+| Ibrahim Hassan | Blue Team (Foundation) | 5–20 | [ibrahim-hassan.md](ibrahim-hassan.md) |
+| David Onoja | Blue Team Lead (Advanced) | 9–20 | [david-onoja.md](david-onoja.md) |
+| Temi Adebola | Red Team Lead | 9–20 | [temi-adebola.md](temi-adebola.md) |
+| Lanre Shittu | ML/AI Lead | 5–20 | [lanre-shittu.md](lanre-shittu.md) |
+| Jeremiah Okino | Compliance Lead | 5–20 | [jeremiah-okino.md](jeremiah-okino.md) |
+| DevRel & PR | Developer Relations | 9–20 | [devrel-pr.md](devrel-pr.md) |
+
+## Source of Truth
+
+The authoritative readiness reference is `docs/plans/maintainer-timelines-bank-pilot-readiness.md`, which as of 2026-07-07 reflects the live-verified state of the Azure deployment (all blockers resolved, 16/16 acceptance gate checks passed). These briefs are preserved as a historical record of maintainer task assignments from the 2026-07-03 plan.
+
+## Consolidated View
+
+For a combined timeline across all maintainers, see `docs/plans/maintainer-task-briefs.md`.

--- a/docs/internal/maintainers/ajibola-shokunbi.md
+++ b/docs/internal/maintainers/ajibola-shokunbi.md
@@ -1,0 +1,72 @@
+# Internal Brief — Ajibola Shokunbi
+
+**Role:** Core Software Lead  
+**GitHub:** @jiboo2022  
+**Color Team:** Infrastructure / Yellow  
+**Active Window:** Weeks 1–20  
+**Status:** Critical path owner for the entire bank-pilot timeline
+
+---
+
+## Mission
+
+Build the application-layer substrate that every other maintainer depends on. If Ajibola's work slips in Phase 0 or Phase 2, the entire timeline slips.
+
+---
+
+## Atomic Tasks
+
+### Phase 0 — Foundation (Weeks 1–4)
+
+| Task | Weeks | Deliverable | Unblocks |
+|------|-------|-------------|----------|
+| AJIBOLA-001 | 1 | Production ORM base + session factory (`db/base.py`, `db/session.py`, `db/health.py`) | All DB-backed models |
+| AJIBOLA-002 | 1–2 | Wire `EventStore` into `Simulator` by default | P0-5 audit trail |
+| AJIBOLA-003 | 2–3 | Shared event bus (`core/event_bus.py`) | Red/blue/purple/white/black communication |
+| AJIBOLA-005 | 3–4 | Core simulation ORM models (`db/models/simulation.py`, `db/models/campaign.py`) | P0-6 persistence |
+
+### Phase 1 — Security & Multi-Tenancy (Weeks 5–8)
+
+| Task | Weeks | Deliverable | Unblocks |
+|------|-------|-------------|----------|
+| AJIBOLA-004 | 5–6 | API auth middleware + `User`/`Role`/`Tenant` models | Ibrahim's RBAC |
+| AJIBOLA-006 | 7–8 | Multi-tenant isolation (`db/tenant_filter.py`, `TenantMiddleware`) | All tenant-scoped queries |
+
+### Phase 2 — Orchestration (Weeks 9–14)
+
+| Task | Weeks | Deliverable | Unblocks |
+|------|-------|-------------|----------|
+| AJIBOLA-007 | 9–11 | `ExerciseOrchestrator` — red→blue→purple→black chain | End-to-end platform |
+| AJIBOLA-008 | 11–12 | Wire `Simulator` output to Blue Team via event bus | Red→blue detection loop |
+| AJIBOLA-009 | 13–14 | Enterprise integrations API (`api/routers/integrations.py`) | API-managed deployments |
+
+### Phase 4 — Pilot Validation (Weeks 19–20)
+
+| Task | Weeks | Deliverable |
+|------|-------|-------------|
+| AJIBOLA-010 | 19–20 | Full end-to-end pilot dry-run and sign-off |
+
+---
+
+## Key Collaboration Points
+
+- **Omolara:** Ajibola defines ORM models; Omolara creates Alembic migrations. Weekly Monday sync.
+- **Ibrahim:** Ajibola provides auth models; Ibrahim builds RBAC enforcement.
+- **Jeremiah:** Ajibola wires `EventStore`/`Simulator`; Jeremiah builds audit sink and hash chain.
+- **Temi/David/Lanre:** Ajibola provides event bus + orchestrator; they plug in color teams.
+
+---
+
+## Exit Criteria
+
+1. `from ciicerone.db import Base, get_session` works.
+2. `Simulator.execute_simulation()` persists results and emits events.
+3. `ciicerone exercise run --scenario templates/finance_bec.yaml --teams red,blue` runs end-to-end.
+4. All API endpoints require auth and enforce tenant isolation.
+
+---
+
+## Risks
+
+- Single point of failure for Weeks 1–14.
+- Recommend pairing with Omolara on event bus and with Ibrahim on API auth.

--- a/docs/internal/maintainers/omolara-oladipupo.md
+++ b/docs/internal/maintainers/omolara-oladipupo.md
@@ -1,0 +1,67 @@
+# Internal Brief — Omolara Oladipupo
+
+**Role:** Infrastructure Lead  
+**GitHub:** @laradipupo  
+**Color Team:** Yellow / Green  
+**Active Window:** Weeks 1–20
+
+---
+
+## Mission
+
+Own the deployment-layer infrastructure: database hardening, migrations, air-gap egress controls, and the Yellow/Green teams.
+
+---
+
+## Atomic Tasks
+
+### Phase 0 — Foundation (Weeks 1–4)
+
+| Task | Weeks | Deliverable | Unblocks |
+|------|-------|-------------|----------|
+| OMOLARA-001 | 1–2 | Harden PostgreSQL Docker Compose; backup/restore scripts | Persistence infrastructure |
+| OMOLARA-002 | 3–4 | Alembic migration for core persistence tables | Domain model deployment |
+
+### Phase 1 — Security & Air-Gap (Weeks 5–8)
+
+| Task | Weeks | Deliverable | Unblocks |
+|------|-------|-------------|----------|
+| OMOLARA-003 | 5–8 | Migrations for auth, tenancy, audit, all domain tables | Production deployment |
+| OMOLARA-004 | 7–8 | Network-level egress controls for air-gapped mode | P0-7 "no data leaves" |
+
+### Phase 3 — Team Completion (Weeks 15–18)
+
+| Task | Weeks | Deliverable | Unblocks |
+|------|-------|-------------|----------|
+| OMOLARA-005 | 15–16 | Yellow Team: secure build validation (`core/secure_build_engine.py`) | P0-2, P2-1 |
+| OMOLARA-006 | 17–18 | Green Team: remediation tracking (`core/remediation_engine.py`) | P0-2, P2-1 |
+
+### Phase 4 — Pilot Validation (Weeks 19–20)
+
+| Task | Weeks | Deliverable |
+|------|-------|-------------|
+| OMOLARA-007 | 19–20 | Air-gapped deployment, migrations, backup/restore verification |
+
+---
+
+## Key Collaboration Points
+
+- **Ajibola:** Ajibola defines ORM models; Omolara creates migrations. Weekly Monday sync.
+- **Lanre:** Coordinate air-gap model bundle with network egress controls.
+- **Jeremiah/Ibrahim:** Provide DB migrations for audit, auth, and blue-team tables.
+
+---
+
+## Exit Criteria
+
+1. PostgreSQL data persists across container restarts.
+2. All new tables have Alembic migrations.
+3. `AIR_GAPPED_MODE=true` blocks external egress.
+4. Yellow/Green teams participate in the exercise orchestrator.
+
+---
+
+## Risks
+
+- Migration coordination depends on Ajibola's model definitions.
+- Air-gap network policy must be tested in a real K8s/Docker environment.


### PR DESCRIPTION
This PR adds internal documentation protection and updates maintainer routing for the 7 current maintainers.

## Changes

### Internal Docs Protection
- New pre-commit hook `block-internal-docs` runs on commit + push
- Blocks staged files matching internal patterns:
  - `docs/internal/` (maintainer briefs)
  - `dev-docs/` (dev documentation)
  - `.githooks/maintainer-forks.json` (fork URLs)
  - `.githooks/route-maintainer.sh` (PR routing logic)
  - `.githooks/pre-commit-identity` (identity validation)
- Allows exceptions for files that must be public:
  - `.pre-commit-config.yaml` (hook config)
  - `.githooks/block-internal-docs.sh` (the hook itself)

### Maintainer Routing Updates
- Removed `@bayulus4great` from all routing configs
- Updated `CODEOWNERS` with current 7 maintainers
- Updated Ajibola/Omolara to Core Software Engineers with vertical split:
  - Ajibola: Simulation & Event Infrastructure (Yellow Team runtime)
  - Omolara: Data & Security Infrastructure (Green Team runtime, deployments, air-gap)
- Added explicit pairing cadence for shared files

### SSH Maintainer Setup Guide
- Added `docs/guides/SSH_MAINTAINER_SETUP.md` for Ed25519 single-device authentication
- Covers key generation, SSH agent, config, GitHub setup, daily workflow
- Maintainer quick reference card with fork/upstream SSH hosts