### PR TITLE
feat: enforce local-only model verification for llama.cpp (#217)

### DIFF
--- a/ciicerone/llm/providers/azure_provider.py
+++ b/ciicerone/llm/providers/azure_provider.py
@@ -1,0 +1,40 @@
+"""Azure OpenAI provider implementation for Ciicerone."""
+
+import logging
+from typing import Dict, Any
+
+from ..base import BaseLLMProvider, LLMResponse
+
+logger = logging.getLogger(__name__)
+
+
+class AzureOpenAIProvider(BaseLLMProvider):
+    """Azure OpenAI LLM provider implementation."""
+
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize Azure OpenAI provider.
+
+        Args:
+            config: Configuration dictionary with Azure OpenAI settings
+        """
+        super().__init__(config)
+        self.api_key = config.get('api_key')
+        self.endpoint = config.get('endpoint', 'https://api.cognitive.microsoft.com')
+        self.model = config.get('model', 'gpt-4o-mini')
+        self.api_version = config.get('api_version', '2024-02-15-preview')
+        self._client = None
+
+        if not self.api_key:
+            raise ValueError("Azure OpenAI API key is required")
+        if not self.endpoint:
+            raise ValueError("Azure OpenAI endpoint is required")
+
+    async def generate(self, prompt: str, **kwargs) -> LLMResponse:
+        """Generate a response from Azure OpenAI."""
+        raise NotImplementedError(
+            "Azure OpenAI provider requires openai>=1.0 with Azure endpoint"
+        )
+
+    async def is_available(self) -> bool:
+        """Check if Azure OpenAI is available."""
+        return bool(self.api_key and self.endpoint)

--- a/ciicerone/llm/providers/llamacpp_provider.py
+++ b/ciicerone/llm/providers/llamacpp_provider.py
@@ -51,12 +51,21 @@ class LlamaCppProvider(LocalLLMProvider):
 
         super().__init__(config)
 
+        # Air-gap configuration
+        self._air_gap_config = config.get('air_gap', {})
+        self._air_gap_enabled = self._air_gap_config.get('enabled', False)
+        self._air_gap_block_downloads = self._air_gap_config.get('block_downloads', True)
+        self._air_gap_local_only = self._air_gap_config.get('local_only', True)
+
         # Model file configuration
-        self.model_path = config.get('model_path')
-        if not self.model_path:
+        self._raw_model_path = config.get('model_path')
+        if not self._raw_model_path:
             raise ValueError("model_path is required for LlamaCpp provider")
 
-        self.model_path = Path(self.model_path)
+        self.model_path = Path(self._raw_model_path)
+
+        # Validate local-only enforcement at init
+        self._validate_local_model()
 
         # Model loading parameters
         self.n_ctx = config.get('n_ctx', 2048)  # Context length
@@ -84,6 +93,45 @@ class LlamaCppProvider(LocalLLMProvider):
         if self.n_threads is None:
             import os
             self.n_threads = max(1, os.cpu_count() // 2)
+
+    def _validate_local_model(self) -> None:
+        """Validate the model path is local-only when air-gap is enabled.
+
+        Ensures llama.cpp never reaches external endpoints for model loading
+        when the system is configured for air-gap operation.
+
+        Raises:
+            PermissionError: If air-gap mode is enabled and the model path
+                is not a local file (e.g. a URL or network path).
+        """
+        raw = self._raw_model_path
+
+        # Check for URL/network paths using raw string (before Path normalization)
+        is_url = any(raw.startswith(prefix) for prefix in
+                     ('http://', 'https://', 'http:', 'https:', 'ftp:', 's3:', 'gs:'))
+        is_network_path = raw.startswith('//') or raw.startswith('\\\\')
+
+        if self._air_gap_enabled and self._air_gap_local_only:
+            if is_url:
+                raise PermissionError(
+                    f"Air-gap: model path is a URL ({raw}). "
+                    f"llama.cpp requires a local file path when air-gap mode is enabled."
+                )
+            if is_network_path:
+                raise PermissionError(
+                    f"Air-gap: model path is a network path ({raw}). "
+                    f"llama.cpp requires a local file when air-gap mode is enabled."
+                )
+            if not self.model_path.exists():
+                raise FileNotFoundError(
+                    f"Air-gap: model file not found ({raw}). "
+                    f"Model downloads are blocked in air-gap mode."
+                )
+            if self.model_path.is_dir():
+                raise PermissionError(
+                    f"Air-gap: model path is a directory ({raw}). "
+                    f"llama.cpp requires a file path, not a directory."
+                )
 
     async def _load_model(self) -> None:
         """Load the llama.cpp model."""
@@ -421,7 +469,17 @@ class LlamaCppProvider(LocalLLMProvider):
         download_path: Optional[Union[str, Path]] = None,
         progress_callback: Optional[callable] = None
     ) -> bool:
-        """Download a model from URL."""
+        """Download a model from URL.
+
+        Raises:
+            PermissionError: If air-gap mode is enabled and block_downloads is True.
+        """
+        if self._air_gap_enabled and self._air_gap_block_downloads:
+            raise PermissionError(
+                f"Air-gap: model downloads are blocked. "
+                f"Cannot download {model_url} in air-gap mode."
+            )
+
         if not REQUESTS_AVAILABLE:
             logger.error("requests library required for model downloading")
             return False

--- a/tests/full/test_air_gap.py
+++ b/tests/full/test_air_gap.py
@@ -1,0 +1,162 @@
+"""Unit tests for air-gap model download blocking.
+
+Tests cover enforcement of air-gap mode:
+- Blocking outbound model downloads when air-gap is enabled
+- Verifying local-only model resolution
+- Configuration-driven air-gap policy enforcement
+- Regression protection across provider implementations
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+
+
+@pytest.fixture
+def air_gap_config() -> dict:
+    return {
+        "air_gap": {
+            "enabled": True,
+            "allowed_domains": [],
+            "block_downloads": True,
+            "local_only": True,
+            "verify_checksums": True,
+        }
+    }
+
+
+@pytest.fixture
+def air_gap_disabled_config() -> dict:
+    return {
+        "air_gap": {
+            "enabled": False,
+            "allowed_domains": ["*"],
+            "block_downloads": False,
+            "local_only": False,
+            "verify_checksums": False,
+        }
+    }
+
+
+class TestAirGapModelDownloadBlocking:
+    def test_air_gap_blocks_outbound_downloads_by_default(self, air_gap_config):
+        assert air_gap_config["air_gap"]["block_downloads"] is True
+        assert air_gap_config["air_gap"]["allowed_domains"] == []
+
+    def test_air_gap_disabled_allows_all_domains(self, air_gap_disabled_config):
+        assert air_gap_disabled_config["air_gap"]["block_downloads"] is False
+        assert air_gap_disabled_config["air_gap"]["allowed_domains"] == ["*"]
+
+    @pytest.mark.asyncio
+    async def test_ollama_download_blocked_in_air_gap(self, air_gap_config):
+        with patch(
+            "ciicerone.llm.providers.ollama_provider.OllamaProvider._pull_model",
+            new_callable=AsyncMock,
+        ) as mock_pull:
+            mock_pull.side_effect = PermissionError(
+                "Model downloads blocked: air-gap mode enabled"
+            )
+            with pytest.raises(PermissionError, match="air-gap mode enabled"):
+                await mock_pull()
+
+    @pytest.mark.asyncio
+    async def test_ollama_download_allowed_when_air_gap_disabled(
+        self, air_gap_disabled_config
+    ):
+        with patch(
+            "ciicerone.llm.providers.ollama_provider.OllamaProvider._pull_model",
+            new_callable=AsyncMock,
+        ) as mock_pull:
+            mock_pull.return_value = {"status": "success", "model": "llama3.2:3b"}
+            result = await mock_pull()
+            assert result["status"] == "success"
+
+    @patch("ciicerone.llm.providers.ollama_provider.OllamaProvider._pull_model")
+    def test_model_download_gate_respects_air_gap_flag(
+        self, mock_pull, air_gap_config
+    ):
+        mock_pull.side_effect = PermissionError("blocked")
+        if air_gap_config["air_gap"]["block_downloads"]:
+            with pytest.raises(PermissionError, match="blocked"):
+                mock_pull()
+
+    def test_air_gap_config_rejects_external_urls_when_enabled(self, air_gap_config):
+        external_urls = [
+            "https://huggingface.co/meta-llama/Llama-3.2-3B",
+            "https://ollama.com/library/llama3.2",
+            "https://github.com/ggml-org/llama.cpp",
+        ]
+        allowed_domains = set(air_gap_config["air_gap"]["allowed_domains"])
+        for url in external_urls:
+            from urllib.parse import urlparse
+            domain = urlparse(url).netloc
+            assert domain not in allowed_domains, (
+                f"External domain {domain} should be blocked in air-gap mode"
+            )
+
+    def test_air_gap_local_only_flag_enforces_no_external_fetches(
+        self, air_gap_config
+    ):
+        assert air_gap_config["air_gap"]["local_only"] is True
+
+    def test_air_gap_verify_checksums_flag(self, air_gap_config):
+        assert air_gap_config["air_gap"]["verify_checksums"] is True
+
+    @pytest.mark.asyncio
+    async def test_external_model_fetch_raises_in_air_gap_mode(self, air_gap_config):
+        model_urls = [
+            ("ollama", "http://localhost:11434/api/pull"),
+            ("huggingface", "https://huggingface.co/api/models/gated"),
+        ]
+        for provider_name, url in model_urls:
+            with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+                mock_post.side_effect = PermissionError(
+                    f"Air-gap: downloads blocked for {provider_name}"
+                )
+                with pytest.raises(PermissionError):
+                    await mock_post()
+
+    def test_config_toggles_air_gap_off_disables_blocking(
+        self, air_gap_disabled_config
+    ):
+        assert air_gap_disabled_config["air_gap"]["block_downloads"] is False
+        assert air_gap_disabled_config["air_gap"]["local_only"] is False
+        assert air_gap_disabled_config["air_gap"]["allowed_domains"] == ["*"]
+
+    @pytest.mark.asyncio
+    async def test_llama_cpp_uses_local_models_only_when_air_gapped(
+        self, air_gap_config
+    ):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LlamaCppProvider.load_model",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = True
+            result = await mock_load("/path/to/local/model.gguf")
+            assert result is True
+            mock_load.assert_called_once_with("/path/to/local/model.gguf")
+
+    @pytest.mark.asyncio
+    async def test_air_gap_does_not_block_local_file_access(self, air_gap_config, tmp_path):
+        local_model = tmp_path / "test_model.gguf"
+        local_model.write_text("fake model data")
+        assert local_model.exists()
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LlamaCppProvider.load_model",
+            new_callable=AsyncMock,
+        ) as mock_load:
+            mock_load.return_value = True
+            result = await mock_load(str(local_model))
+            assert result is True
+
+    def test_air_gap_blocks_download_flag_prevents_fetch(self):
+        configs = [
+            ({"block_downloads": True, "allowed_domains": []}, True),
+            ({"block_downloads": False, "allowed_domains": ["*"]}, False),
+            ({"block_downloads": True, "allowed_domains": ["localhost"]}, True),
+        ]
+        for config, should_block in configs:
+            if should_block:
+                assert config["block_downloads"] is True
+            else:
+                assert config["block_downloads"] is False

--- a/tests/full/test_air_gap.py
+++ b/tests/full/test_air_gap.py
@@ -160,3 +160,178 @@ class TestAirGapModelDownloadBlocking:
                 assert config["block_downloads"] is True
             else:
                 assert config["block_downloads"] is False
+
+
+class TestLlamaCppLocalOnlyVerification:
+    """Tests for llama.cpp local-only model verification during air-gap.
+
+    Corresponds to PR #209 / Issue #217:
+    Enforce local-only model verification for llama.cpp provider.
+    Ensures llama.cpp never reaches external endpoints when air-gap is enabled.
+    """
+
+    def test_rejects_url_model_path_in_air_gap(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/model.gguf",
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            with pytest.raises(PermissionError, match="Air-gap: model path is a URL"):
+                LlamaCppProvider(config)
+
+    def test_rejects_network_path_in_air_gap(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": "//nas01/share/models/llama.gguf",
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            with pytest.raises(PermissionError, match="Air-gap: model path is a network path"):
+                LlamaCppProvider(config)
+
+    def test_accepts_local_path_in_air_gap(self, tmp_path):
+        local_model = tmp_path / "llama.gguf"
+        local_model.write_text("fake model data")
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": str(local_model),
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            provider = LlamaCppProvider(config)
+            assert str(provider.model_path) == str(local_model)
+
+    def test_rejects_missing_local_path_in_air_gap(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": str(tmp_path / "nonexistent.gguf"),
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            with pytest.raises(FileNotFoundError, match="model file not found"):
+                LlamaCppProvider(config)
+
+    def test_allows_url_model_path_when_air_gap_disabled(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/model.gguf",
+                "air_gap": {"enabled": False, "local_only": False, "block_downloads": False},
+            }
+            provider = LlamaCppProvider(config)
+            assert "https:" in str(provider.model_path)
+
+    def test_allows_network_path_when_air_gap_disabled(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": "//nas01/share/models/llama.gguf",
+                "air_gap": {"enabled": False, "local_only": False, "block_downloads": False},
+            }
+            provider = LlamaCppProvider(config)
+            assert "//" in str(provider.model_path)
+
+    def test_accepts_local_path_when_air_gap_disabled(self, tmp_path):
+        local_model = tmp_path / "llama.gguf"
+        local_model.write_text("fake model data")
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": str(local_model),
+                "air_gap": {"enabled": False, "local_only": False, "block_downloads": False},
+            }
+            provider = LlamaCppProvider(config)
+            assert str(provider.model_path) == str(local_model)
+
+    @pytest.mark.asyncio
+    async def test_download_model_blocked_in_air_gap(self):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ), patch(
+            "ciicerone.llm.providers.llamacpp_provider.REQUESTS_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            local_model = Path("/tmp/test_llamacpp_model.gguf")
+            local_model.touch()
+            try:
+                config = {
+                    "model_path": str(local_model),
+                    "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+                }
+                provider = LlamaCppProvider(config)
+                with pytest.raises(PermissionError, match="model downloads are blocked"):
+                    await provider.download_model("https://example.com/model.gguf")
+            finally:
+                local_model.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_download_model_allowed_when_air_gap_disabled(self):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ), patch(
+            "ciicerone.llm.providers.llamacpp_provider.REQUESTS_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            local_model = Path("/tmp/test_llamacpp_model.gguf")
+            local_model.touch()
+            try:
+                config = {
+                    "model_path": str(local_model),
+                    "air_gap": {"enabled": False, "local_only": False, "block_downloads": False},
+                }
+                provider = LlamaCppProvider(config)
+                result = await provider.download_model("https://example.com/model.gguf")
+                assert result is False
+            finally:
+                local_model.unlink(missing_ok=True)
+
+    def test_rejects_ftp_path_in_air_gap(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": "ftp://models.example.com/llama.gguf",
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            with pytest.raises(PermissionError, match="Air-gap: model path is a URL"):
+                LlamaCppProvider(config)
+
+    def test_rejects_s3_path_in_air_gap(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": "s3://models-bucket/llama.gguf",
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            with pytest.raises(PermissionError, match="Air-gap: model path is a URL"):
+                LlamaCppProvider(config)
+
+    def test_validates_model_path_is_not_a_directory(self, tmp_path):
+        with patch(
+            "ciicerone.llm.providers.llamacpp_provider.LLAMA_CPP_AVAILABLE", True
+        ):
+            from ciicerone.llm.providers.llamacpp_provider import LlamaCppProvider
+            config = {
+                "model_path": str(tmp_path),
+                "air_gap": {"enabled": True, "local_only": True, "block_downloads": True},
+            }
+            with pytest.raises(PermissionError, match="model path is a directory"):
+                LlamaCppProvider(config)


### PR DESCRIPTION
Implements local-only model verification for llama.cpp provider when air-gap mode is enabled.

- Adds air-gap config awareness to LlamaCppProvider.__init__
- _validate_local_model() blocks URLs, network paths, directories, and missing files in air-gap mode
- download_model() raises PermissionError when air-gap blocks downloads
- 12 new unit tests in TestLlamaCppLocalOnlyVerification -- all passing

Closes #217