### PR TITLE
[CRITICAL] fix(ci): resolve conftest import crash blocking all PRs

### DIFF
--- a/ciicerone/core/postgres_event_store.py
+++ b/ciicerone/core/postgres_event_store.py
@@ -25,6 +25,7 @@ except ImportError:
     ASYNCPG_AVAILABLE = False
     Pool = Any
     Connection = Any
+    Record = Any
 
 from .event_sourcing import (
     Event,
@@ -580,7 +581,7 @@ class PostgresEventStore:
     # Helpers
     # =========================================================================
 
-    def _row_to_event(self, row: asyncpg.Record) -> Event:
+    def _row_to_event(self, row: "asyncpg.Record") -> Event:
         """Convert database row to Event object."""
         return Event(
             event_id=row['event_id'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
     "faker>=20.1.0",
     "httpx>=0.25.2",
     "respx>=0.20.2",
+    "pytest-asyncio>=0.21.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Emergency CI Fix

**Root cause:** `asyncpg.Record` type annotation in `postgres_event_store.py` crashes when `asyncpg` isn't installed (CI test job only installs `[test]` deps, not `[dev]`).

**Cascade:**
1. `conftest.py` import chain hits `postgres_event_store.py`
2. `NameError` on `asyncpg.Record`
3. pytest-asyncio never loads
4. `asyncio_mode = auto` appears as unknown config option
5. **All PR CI pipelines fail**

**Affected PRs:** #212, #211, #205, #204, #185, #184, #183, #181, #180, #178, #176, #174, #172, #170, #168, #167

**Fixes:**
- `Record = Any` fallback in asyncpg except block
- String literal `"asyncpg.Record"` for lazy evaluation
- Add `pytest-asyncio` to `[project.optional-dependencies] test = [...]"

**Priority:** P0 — blocks entire CI pipeline