### PR TITLE
[HOTFIX] fix(cli): add missing CLI module stubs to master

### DIFF
--- a/ciicerone/cli/blue_team.py
+++ b/ciicerone/cli/blue_team.py
@@ -1,0 +1,15 @@
+"""Blue team defense commands for Ciicerone CLI."""
+
+import click
+
+
+@click.group()
+def blue_team():
+    """Execute blue team defense and monitoring operations."""
+    pass
+
+
+@blue_team.command("monitor")
+def monitor():
+    """Start blue team monitoring."""
+    click.echo("Blue team monitoring placeholder.")

--- a/ciicerone/cli/client_data.py
+++ b/ciicerone/cli/client_data.py
@@ -1,0 +1,15 @@
+"""Client data management commands for Ciicerone CLI."""
+
+import click
+
+
+@click.group()
+def client_data():
+    """Manage client data for threat simulations."""
+    pass
+
+
+@client_data.command("list")
+def list_clients():
+    """List all registered clients."""
+    click.echo("No clients registered yet.")

--- a/ciicerone/cli/quantum.py
+++ b/ciicerone/cli/quantum.py
@@ -1,0 +1,15 @@
+"""Quantum-safe cryptography commands for Ciicerone CLI."""
+
+import click
+
+
+@click.group()
+def quantum():
+    """Manage quantum-safe cryptographic operations."""
+    pass
+
+
+@quantum.command("generate")
+def generate_key():
+    """Generate a quantum-safe key."""
+    click.echo("Quantum key generation placeholder.")

--- a/ciicerone/cli/red_team.py
+++ b/ciicerone/cli/red_team.py
@@ -1,0 +1,15 @@
+"""Red team operations commands for Ciicerone CLI."""
+
+import click
+
+
+@click.group()
+def red_team():
+    """Execute red team operations and threat simulations."""
+    pass
+
+
+@red_team.command("simulate")
+def simulate():
+    """Run a red team simulation."""
+    click.echo("Red team simulation placeholder.")


### PR DESCRIPTION
## Problem

PR #168 introduces imports for , , , and  in  but these modules don't exist on **master**. Any branch that merges/rebases with master will hit:



This affects CI across all PRs.

## Fix

Add minimal click group stubs for all four missing CLI modules.

## Affected branches
PR #168, #170, #172, and any future PRs rebasing onto master.