### PR TITLE
chore(gitignore): prevent .opencode/ and node_modules/ from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,9 @@ coverage.xml
 /dev/
 /dev-docs/
 /archive/
+
+# =========================
+# OPENCODE / AI AGENTS
+# =========================
+.opencode/
+node_modules/


### PR DESCRIPTION
Adds .opencode/ and node_modules/ to .gitignore to prevent accidental commits of AI agent working directories and npm dependencies.