### PR TITLE
feat(api): collaboration room CRUD endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ coverage.xml
 # =========================
 # Prevent commits of AI agent working directories and config files.
 # See archive repo for full documentation on SSH signing keys setup.
-# https://github.com/Ciicerone/ThreatSimGPT-archive
+# https://github.com/Ciicerone/Ciicerone-archive
 .opencode/
 .claude/
 .claude-code/

--- a/ciicerone/api/routers/collaboration.py
+++ b/ciicerone/api/routers/collaboration.py
@@ -1,0 +1,17 @@
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from ciicerone.collaboration.models import CollaborationMessage, Room, RoomMember
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/collaboration", tags=["Collaboration"])
+
+room_manager = None
+
+
+def set_room_manager(rm):
+    global room_manager
+    room_manager = rm

--- a/ciicerone/api/routers/collaboration.py
+++ b/ciicerone/api/routers/collaboration.py
@@ -15,3 +15,27 @@ room_manager = None
 def set_room_manager(rm):
     global room_manager
     room_manager = rm
+
+
+@router.get("/rooms", response_model=List[Room])
+async def list_rooms(active_only: bool = Query(True)):
+    if room_manager is None:
+        raise HTTPException(status_code=503, detail="Room manager not initialized")
+    return await room_manager.list_rooms(active_only=active_only)
+
+
+@router.post("/rooms", response_model=Room, status_code=201)
+async def create_room(name: str, description: str = "", created_by: str = ""):
+    if room_manager is None:
+        raise HTTPException(status_code=503, detail="Room manager not initialized")
+    return await room_manager.create_room(name=name, created_by=created_by, description=description)
+
+
+@router.get("/rooms/{room_id}", response_model=Room)
+async def get_room(room_id: str):
+    if room_manager is None:
+        raise HTTPException(status_code=503, detail="Room manager not initialized")
+    room = await room_manager.get_room(room_id)
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+    return room

--- a/ciicerone/llm/__init__.py
+++ b/ciicerone/llm/__init__.py
@@ -1,4 +1,4 @@
-"""Comprehensive LLM integration package for ThreatSimGPT.
+"""Comprehensive LLM integration package for Ciicerone.
 
 This package provides complete LLM integration including:
 - Provider abstraction layer (OpenAI, Anthropic)

--- a/ciicerone/llm/advanced_integration.py
+++ b/ciicerone/llm/advanced_integration.py
@@ -1,4 +1,4 @@
-"""Advanced Prompt Engineering Integration for ThreatSimGPT.
+"""Advanced Prompt Engineering Integration for Ciicerone.
 
 This module integrates all 6 levels of advanced prompt engineering techniques
 into a unified system for optimal threat simulation content generation.
@@ -43,7 +43,7 @@ class AdvancedGenerationResult:
 
 class AdvancedPromptEngineering:
     """
-    Unified Advanced Prompt Engineering System for ThreatSimGPT
+    Unified Advanced Prompt Engineering System for Ciicerone
 
     Integrates all 6 levels of advanced prompt engineering:
     1. Chain-of-Thought (CoT) prompting

--- a/ciicerone/llm/advanced_prompts.py
+++ b/ciicerone/llm/advanced_prompts.py
@@ -1,4 +1,4 @@
-"""Advanced prompt engineering implementations for ThreatSimGPT.
+"""Advanced prompt engineering implementations for Ciicerone.
 
 This module implements cutting-edge prompt engineering techniques based on recent research:
 - Chain-of-Thought (CoT) prompting (Wei et al., 2022)

--- a/ciicerone/llm/advanced_reasoning.py
+++ b/ciicerone/llm/advanced_reasoning.py
@@ -1,4 +1,4 @@
-"""Tree of Thoughts and advanced reasoning implementations for ThreatSimGPT.
+"""Tree of Thoughts and advanced reasoning implementations for Ciicerone.
 
 This module implements Levels 3-6 of advanced prompt engineering:
 - Tree of Thoughts (ToT) for complex scenario planning

--- a/ciicerone/llm/enhanced_prompts.py
+++ b/ciicerone/llm/enhanced_prompts.py
@@ -1,4 +1,4 @@
-"""Enhanced Prompt Engineering System for ThreatSimGPT.
+"""Enhanced Prompt Engineering System for Ciicerone.
 
 This module implements production-grade prompt templates for all content types,
 following industry best practices from OpenAI, Anthropic, and Google research.

--- a/ciicerone/llm/manager.py
+++ b/ciicerone/llm/manager.py
@@ -1,4 +1,4 @@
-"""LLM manager for ThreatSimGPT content generation.
+"""LLM manager for Ciicerone content generation.
 
 This module provides a production-ready LLM manager that handles
 content generation for threat scenarios with multiple provider support.

--- a/ciicerone/llm/prompts.py
+++ b/ciicerone/llm/prompts.py
@@ -1,4 +1,4 @@
-"""Advanced prompt engineering framework for ThreatSimGPT.
+"""Advanced prompt engineering framework for Ciicerone.
 
 This module provides sophisticated prompt templates, context injection,
 and content generation strategies for various threat simulation scenarios.

--- a/ciicerone/llm/providers/openrouter_provider.py
+++ b/ciicerone/llm/providers/openrouter_provider.py
@@ -1,4 +1,4 @@
-"""OpenRouter LLM provider for ThreatSimGPT.
+"""OpenRouter LLM provider for Ciicerone.
 
 This provider integrates with OpenRouter API to access multiple LLM models
 through a single API interface, providing flexibility and cost-effectiveness.
@@ -27,10 +27,10 @@ class OpenRouterProvider(BaseLLMProvider):
         self.api_key = config.get('api_key')
         self.model = config.get('model', 'qwen/qwen3-vl-235b-a22b-thinking')  # Default to working Qwen model
         self.base_url = config.get('base_url', 'https://openrouter.ai/api/v1')
-        self.app_name = config.get('app_name', 'ThreatSimGPT')
-        self.site_url = config.get('site_url', 'https://github.com/threatsimgpt-AI/ThreatSimGPT')
+        self.app_name = config.get('app_name', 'Ciicerone')
+        self.site_url = config.get('site_url', 'https://github.com/Ciicerone/Ciicerone')
 
-        # Popular model options for ThreatSimGPT (including user's working Qwen model)
+        # Popular model options for Ciicerone (including user's working Qwen model)
         self.recommended_models = {
             'qwen-3l-235b': 'qwen/qwen3-vl-235b-a22b-thinking',  # User's preferred working model
             'qwen-2.5-72b': 'qwen/qwen-2.5-72b-instruct',
@@ -218,7 +218,7 @@ class OpenRouterProvider(BaseLLMProvider):
 
     def _get_system_prompt(self, scenario_type: str) -> str:
         """Get system prompt based on scenario type."""
-        base_prompt = """You are ThreatSimGPT, an AI assistant specialized in generating realistic threat scenario samples for cybersecurity training and agent development.
+        base_prompt = """You are Ciicerone, an AI assistant specialized in generating realistic threat scenario samples for cybersecurity training and agent development.
 
 Your role is to create actual threat scenario content that demonstrates how real attacks work, which will be used to:
 1. Train security professionals to recognize threats

--- a/ciicerone/llm/rlhf_multiagent.py
+++ b/ciicerone/llm/rlhf_multiagent.py
@@ -1,4 +1,4 @@
-"""RLHF Optimization and Multi-Agent Prompt Engineering for ThreatSimGPT.
+"""RLHF Optimization and Multi-Agent Prompt Engineering for Ciicerone.
 
 This module implements the final two levels of advanced prompt engineering:
 - Level 5: Reinforcement Learning from Human Feedback (RLHF) optimization


### PR DESCRIPTION
## Summary
Add room CRUD endpoints to the collaboration router.

## What's Included
- GET /rooms — list rooms with active_only filter
- POST /rooms — create new room
- GET /rooms/{room_id} — fetch room by ID (404 if missing)
- 503 guard when RoomManager not initialized

## Stack Position
Branch 2 of 4 → depends on #237 (feat/collaboration-router-setup)

Closes #239
