### PR TITLE
feat(intelligence): hypothesis validation domain models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ coverage.xml
 # =========================
 # Prevent commits of AI agent working directories and config files.
 # See archive repo for full documentation on SSH signing keys setup.
-# https://github.com/Ciicerone/ThreatSimGPT-archive
+# https://github.com/Ciicerone/Ciicerone-archive
 .opencode/
 .claude/
 .claude-code/

--- a/ciicerone/intelligence/__init__.py
+++ b/ciicerone/intelligence/__init__.py
@@ -50,6 +50,20 @@ from .mitre_attack import (
     create_mitre_attack_engine,
 )
 
+# Hypothesis Validation Pipeline — Domain Models (Issue #234, Branch 1)
+from .hypothesis import (
+    HypothesisStatus,
+    LikelihoodFactor,
+    ImpactFactor,
+    DetectabilityFactor,
+    HypothesisSource,
+    ValidationStatus,
+    LikelihoodScore,
+    ImpactScore,
+    DetectabilityScore,
+    HypothesisValidationResult,
+)
+
 # Threat Hunting & CVE Intelligence
 # TODO: Implement threat_hunting module and re-enable imports
 # from .threat_hunting import (
@@ -135,6 +149,18 @@ __all__ = [
     "TACTIC_DESCRIPTIONS",
     "PLATFORMS",
     "create_mitre_attack_engine",
+
+    # Hypothesis Validation Pipeline — Domain Models
+    "HypothesisStatus",
+    "LikelihoodFactor",
+    "ImpactFactor",
+    "DetectabilityFactor",
+    "HypothesisSource",
+    "ValidationStatus",
+    "LikelihoodScore",
+    "ImpactScore",
+    "DetectabilityScore",
+    "HypothesisValidationResult",
 
     # Threat Hunting & CVE Intelligence
     # TODO: Implement threat_hunting module and re-enable

--- a/ciicerone/intelligence/hypothesis.py
+++ b/ciicerone/intelligence/hypothesis.py
@@ -1,0 +1,173 @@
+"""Hypothesis Validation Pipeline for Blue Team threat hunting.
+
+Scores hunting hypotheses by likelihood, impact, and detectability
+to prioritize the most promising leads for investigation.
+
+Issue: Hypothesis validation pipeline (scores by likelihood, impact, detectability)
+Owner: David Onoja (@ocheme1107)
+Track: Blue Team / Detection Engineering
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set, Tuple
+from uuid import uuid4
+
+from .mitre_attack import (
+    MITREATTACKEngine,
+    ATTACKTechnique,
+    ATTACKGroup,
+    ATTACKMatrix,
+    ENTERPRISE_TACTICS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Enums & Constants
+# ============================================================================
+
+
+class HypothesisStatus(str, Enum):
+    DRAFT = "draft"
+    VALIDATED = "validated"
+    IN_PROGRESS = "in_progress"
+    CONFIRMED = "confirmed"
+    FALSE_POSITIVE = "false_positive"
+    INCONCLUSIVE = "inconclusive"
+
+
+class LikelihoodFactor(str, Enum):
+    THREAT_ACTOR_USAGE = "threat_actor_usage"
+    TECHNIQUE_PREVALENCE = "technique_prevalence"
+    HISTORICAL_INCIDENTS = "historical_incidents"
+    CURRENT_THREAT_LANDSCAPE = "current_threat_landscape"
+    PLATFORM_RELEVANCE = "platform_relevance"
+    INDUSTRY_TARGETING = "industry_targeting"
+    RECENT_CAMPAIGNS = "recent_campaigns"
+    TOOL_AVAILABILITY = "tool_availability"
+    PUBLIC_EXPLOITS = "public_exploits"
+    EASE_OF_EXECUTION = "ease_of_execution"
+
+
+class ImpactFactor(str, Enum):
+    DATA_EXFILTRATION = "data_exfiltration"
+    SYSTEM_COMPROMISE = "system_compromise"
+    CREDENTIAL_THEFT = "credential_theft"
+    LATERAL_MOVEMENT = "lateral_movement"
+    PERSISTENCE = "persistence"
+    DEFENSE_EVASION = "defense_evasion"
+    BUSINESS_IMPACT = "business_impact"
+    REGULATORY_VIOLATION = "regulatory_violation"
+    REPUTATIONAL_DAMAGE = "reputational_damage"
+    FINANCIAL_LOSS = "financial_loss"
+
+
+class DetectabilityFactor(str, Enum):
+    DATA_SOURCE_AVAILABILITY = "data_source_availability"
+    DETECTION_RULE_COVERAGE = "detection_rule_coverage"
+    SIGNAL_TO_NOISE_RATIO = "signal_to_noise_ratio"
+    DETECTION_COMPLEXITY = "detection_complexity"
+    FALSE_POSITIVE_RATE = "false_positive_rate"
+    REQUIRED_TOOLING = "required_tooling"
+    ANALYST_SKILL_LEVEL = "analyst_skill_level"
+    CORRELATION_REQUIRED = "correlation_required"
+
+
+class HypothesisSource(str, Enum):
+    MITRE_TECHNIQUE = "mitre_technique"
+    THREAT_INTEL = "threat_intel"
+    HISTORICAL_INCIDENT = "historical_incident"
+    USER_BEHAVIOR_ANALYTICS = "user_behavior_analytics"
+    NETWORK_ANOMALY = "network_anomaly"
+    THREAT_HUNTING = "threat_hunting"
+    INTELLIGENCE_FEED = "intelligence_feed"
+    MANUAL = "manual"
+
+
+class ValidationStatus(str, Enum):
+    PENDING = "pending"
+    VALIDATED = "validated"
+    REJECTED = "rejected"
+    ESCALATED = "escalated"
+
+
+# ============================================================================
+# Scoring Models
+# ============================================================================
+
+
+@dataclass
+class LikelihoodScore:
+    score: float
+    factors: Dict[LikelihoodFactor, float]
+    reasoning: str
+
+    def __post_init__(self):
+        self.score = max(0.0, min(1.0, self.score))
+
+
+@dataclass
+class ImpactScore:
+    score: float
+    factors: Dict[ImpactFactor, float]
+    reasoning: str
+
+    def __post_init__(self):
+        self.score = max(0.0, min(1.0, self.score))
+
+
+@dataclass
+class DetectabilityScore:
+    score: float
+    factors: Dict[DetectabilityFactor, float]
+    reasoning: str
+
+    def __post_init__(self):
+        self.score = max(0.0, min(1.0, self.score))
+
+
+@dataclass
+class HypothesisValidationResult:
+    hypothesis_id: str
+    technique_id: str
+    technique_name: str
+    tactic: str
+    description: str
+    likelihood: LikelihoodScore
+    impact: ImpactScore
+    detectability: DetectabilityScore
+    overall_score: float
+    priority: str
+    recommendation: str
+    supporting_evidence: List[str]
+    related_groups: List[str]
+    related_software: List[str]
+    mitre_mitigations: List[str]
+    status: ValidationStatus
+    validated_at: datetime
+    source: HypothesisSource
+    ttl_hours: int
+
+    @property
+    def risk_score(self) -> float:
+        return self.likelihood.score * self.impact.score
+
+    @property
+    def hunt_priority(self) -> float:
+        return self.overall_score * (1 - self.detectability.score)
+
+    @property
+    def summary(self) -> str:
+        return (
+            f"[{self.priority}] {self.technique_id} - {self.technique_name} "
+            f"(L:{self.likelihood.score:.2f} I:{self.impact.score:.2f} "
+            f"D:{self.detectability.score:.2f} | Overall: {self.overall_score:.2f})"
+        )
+
+

--- a/ciicerone/llm/__init__.py
+++ b/ciicerone/llm/__init__.py
@@ -1,4 +1,4 @@
-"""Comprehensive LLM integration package for ThreatSimGPT.
+"""Comprehensive LLM integration package for Ciicerone.
 
 This package provides complete LLM integration including:
 - Provider abstraction layer (OpenAI, Anthropic)

--- a/ciicerone/llm/advanced_integration.py
+++ b/ciicerone/llm/advanced_integration.py
@@ -1,4 +1,4 @@
-"""Advanced Prompt Engineering Integration for ThreatSimGPT.
+"""Advanced Prompt Engineering Integration for Ciicerone.
 
 This module integrates all 6 levels of advanced prompt engineering techniques
 into a unified system for optimal threat simulation content generation.
@@ -43,7 +43,7 @@ class AdvancedGenerationResult:
 
 class AdvancedPromptEngineering:
     """
-    Unified Advanced Prompt Engineering System for ThreatSimGPT
+    Unified Advanced Prompt Engineering System for Ciicerone
 
     Integrates all 6 levels of advanced prompt engineering:
     1. Chain-of-Thought (CoT) prompting

--- a/ciicerone/llm/advanced_prompts.py
+++ b/ciicerone/llm/advanced_prompts.py
@@ -1,4 +1,4 @@
-"""Advanced prompt engineering implementations for ThreatSimGPT.
+"""Advanced prompt engineering implementations for Ciicerone.
 
 This module implements cutting-edge prompt engineering techniques based on recent research:
 - Chain-of-Thought (CoT) prompting (Wei et al., 2022)

--- a/ciicerone/llm/advanced_reasoning.py
+++ b/ciicerone/llm/advanced_reasoning.py
@@ -1,4 +1,4 @@
-"""Tree of Thoughts and advanced reasoning implementations for ThreatSimGPT.
+"""Tree of Thoughts and advanced reasoning implementations for Ciicerone.
 
 This module implements Levels 3-6 of advanced prompt engineering:
 - Tree of Thoughts (ToT) for complex scenario planning

--- a/ciicerone/llm/enhanced_prompts.py
+++ b/ciicerone/llm/enhanced_prompts.py
@@ -1,4 +1,4 @@
-"""Enhanced Prompt Engineering System for ThreatSimGPT.
+"""Enhanced Prompt Engineering System for Ciicerone.
 
 This module implements production-grade prompt templates for all content types,
 following industry best practices from OpenAI, Anthropic, and Google research.

--- a/ciicerone/llm/manager.py
+++ b/ciicerone/llm/manager.py
@@ -1,4 +1,4 @@
-"""LLM manager for ThreatSimGPT content generation.
+"""LLM manager for Ciicerone content generation.
 
 This module provides a production-ready LLM manager that handles
 content generation for threat scenarios with multiple provider support.

--- a/ciicerone/llm/prompts.py
+++ b/ciicerone/llm/prompts.py
@@ -1,4 +1,4 @@
-"""Advanced prompt engineering framework for ThreatSimGPT.
+"""Advanced prompt engineering framework for Ciicerone.
 
 This module provides sophisticated prompt templates, context injection,
 and content generation strategies for various threat simulation scenarios.

--- a/ciicerone/llm/providers/openrouter_provider.py
+++ b/ciicerone/llm/providers/openrouter_provider.py
@@ -1,4 +1,4 @@
-"""OpenRouter LLM provider for ThreatSimGPT.
+"""OpenRouter LLM provider for Ciicerone.
 
 This provider integrates with OpenRouter API to access multiple LLM models
 through a single API interface, providing flexibility and cost-effectiveness.
@@ -27,10 +27,10 @@ class OpenRouterProvider(BaseLLMProvider):
         self.api_key = config.get('api_key')
         self.model = config.get('model', 'qwen/qwen3-vl-235b-a22b-thinking')  # Default to working Qwen model
         self.base_url = config.get('base_url', 'https://openrouter.ai/api/v1')
-        self.app_name = config.get('app_name', 'ThreatSimGPT')
-        self.site_url = config.get('site_url', 'https://github.com/threatsimgpt-AI/ThreatSimGPT')
+        self.app_name = config.get('app_name', 'Ciicerone')
+        self.site_url = config.get('site_url', 'https://github.com/Ciicerone/Ciicerone')
 
-        # Popular model options for ThreatSimGPT (including user's working Qwen model)
+        # Popular model options for Ciicerone (including user's working Qwen model)
         self.recommended_models = {
             'qwen-3l-235b': 'qwen/qwen3-vl-235b-a22b-thinking',  # User's preferred working model
             'qwen-2.5-72b': 'qwen/qwen-2.5-72b-instruct',
@@ -218,7 +218,7 @@ class OpenRouterProvider(BaseLLMProvider):
 
     def _get_system_prompt(self, scenario_type: str) -> str:
         """Get system prompt based on scenario type."""
-        base_prompt = """You are ThreatSimGPT, an AI assistant specialized in generating realistic threat scenario samples for cybersecurity training and agent development.
+        base_prompt = """You are Ciicerone, an AI assistant specialized in generating realistic threat scenario samples for cybersecurity training and agent development.
 
 Your role is to create actual threat scenario content that demonstrates how real attacks work, which will be used to:
 1. Train security professionals to recognize threats

--- a/ciicerone/llm/rlhf_multiagent.py
+++ b/ciicerone/llm/rlhf_multiagent.py
@@ -1,4 +1,4 @@
-"""RLHF Optimization and Multi-Agent Prompt Engineering for ThreatSimGPT.
+"""RLHF Optimization and Multi-Agent Prompt Engineering for Ciicerone.
 
 This module implements the final two levels of advanced prompt engineering:
 - Level 5: Reinforcement Learning from Human Feedback (RLHF) optimization


### PR DESCRIPTION
## Summary
Add foundational domain models for blue-team hypothesis validation pipeline.

## What's Included
- **Enums**: `HypothesisStatus`, `LikelihoodFactor`, `ImpactFactor`, `DetectabilityFactor`, `HypothesisSource`, `ValidationStatus`
- **Score dataclasses**: `LikelihoodScore`, `ImpactScore`, `DetectabilityScore` (with clamped 0.0–1.0 scores)
- **Result dataclass**: `HypothesisValidationResult` with `risk_score`, `hunt_priority`, and `summary` properties
- **Exports**: Wired into `intelligence/__init__.py`

## Stack Position
Branch 1 of 4 → must merge before `feat/hypothesis-scoring-engines`

- Part of #234
- Closes #149

## Fork
Head repository: `ocheme1107/ThreatSimGPT`
